### PR TITLE
[Fix] : traitement retours graphique impact carbone (#000)

### DIFF
--- a/src/assets/theme/style.css
+++ b/src/assets/theme/style.css
@@ -111,3 +111,7 @@ h3 {
 .text--center {
   text-align: center;
 }
+
+.background-gris {
+  background: var(--background-alt-grey);
+}

--- a/src/components/GraphSuiviEmpreinteCarbone.vue
+++ b/src/components/GraphSuiviEmpreinteCarbone.vue
@@ -1,28 +1,16 @@
 <template>
-  <div class="fr-col-12">
-    <div class="col-demo">
-      <div class="fr-tile fr-enlarge-link fr-tile--horizontal fr-tile--vertical-md graph-container" id="tile-6538">
-        <div class="fr-grid-row">
-          <div class="fr-col-11">
-            <div class="col-demo">
-              <div class="graph-card-custom-body">
-                <div class="fr-tile__title">
-                  <p style="font-size: 2.5vh">Évolution de votre impact carbone</p>
-                </div>
-                <br />
-                <div class="fr-tile__desc">
-                  <div class="graph-schema">
-                    <LineChart :chartData="getDonneesDuGraph" :options="getOptionsDuGraph" />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+  <div class="fr-p-3w background-gris">
+    <h2 class="fr-h5">Évolution de votre impact carbone</h2>
+    <LineChart :chartData="getDonneesDuGraph" :options="getOptionsDuGraph" />
+    <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-mt-2w">
+      <span class="fr-text--sm fr-mb-0">Votre moyenne</span>
+      <div class="legende-graphique legende-graphique--blue"></div>
+      <div class="fr-text--sm fr-mb-0">Variation des suivis</div>
+      <div class="legende-graphique legende-graphique--dashed"></div>
     </div>
   </div>
 </template>
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { LineChart } from "vue-chart-3";
@@ -44,7 +32,7 @@ export default defineComponent({
       return this.datesDuGraph;
     },
 
-    getDonneesDuGraph() {
+    getDonneesDuGraph() {      
       return {
         labels: this.datesDuGraph,
         datasets: [
@@ -72,17 +60,8 @@ export default defineComponent({
         maintainAspectRatio: false,
         plugins: {
           legend: {
-            display: true,
-            labels: {
-              font: {
-                size: 14,
-                weight: "bold",
-                family: "Marianne,arial,sans-serif",
-              },
-            },
-            position: "right",
-            align: "center",
-          },
+            display: false,
+          }
         },
         scales: {
           y: {
@@ -116,33 +95,18 @@ export default defineComponent({
   },
 });
 </script>
+
 <style scoped>
-.graph-card-custom-body {
-  text-align: left;
-  margin: 20px 20px auto;
-  width: 100%;
-}
+  .legende-graphique {
+    width: 3rem;
+    height: 0;
+    margin: 0 1rem 0 .5rem;
+  }
+  .legende-graphique--blue {
+    border: 4px solid #000091;
+  }
 
-.graph-container {
-  background-color: #f6f6f6;
-  border-radius: 5px;
-}
-
-.graph-schema {
-  height: 50vh;
-}
-
-.legend-graph-container {
-  position: absolute;
-  left: 50%;
-  top: 59%;
-  transform: translate(-50%, -59%);
-  width: 80%;
-  font-weight: bold;
-  color: black;
-}
-
-.legend-graph-place {
-  position: relative;
-}
+  .legende-graphique--dashed {
+    border: 4px dashed #000000;
+  }
 </style>

--- a/src/components/GraphSuiviEmpreinteCarbone.vue
+++ b/src/components/GraphSuiviEmpreinteCarbone.vue
@@ -32,7 +32,7 @@ export default defineComponent({
       return this.datesDuGraph;
     },
 
-    getDonneesDuGraph() {      
+    getDonneesDuGraph() {
       return {
         labels: this.datesDuGraph,
         datasets: [

--- a/src/components/SuiviDuJour.vue
+++ b/src/components/SuiviDuJour.vue
@@ -58,10 +58,10 @@
                   v-if="etapeCourante == 3"
                   class="fr-btn fr-btn-not-rounded redirect-coach-link"
                   id="button-2864"
-                  title="Envoyer le formulaire"
+                  title="Retourner à la page coach"
                   :to="{ name: 'coach' }"
                 >
-                  Retour au coach
+                  Retour à mes actions
                 </router-link>
               </div>
               <br />

--- a/src/components/SuiviDuJourResultats.vue
+++ b/src/components/SuiviDuJourResultats.vue
@@ -1,9 +1,8 @@
 <template>
-  <div class="fr-grid-row fr-grid-row--gutters">
+  <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
     <CarteEmpreinteDuJour :suivi-du-jour-resultats="suiviDuJourResultats" />
     <EmpreinteDuJourDetails :suivi-du-jour-resultats="suiviDuJourResultats" />
   </div>
-  <br />
   <GraphSuiviEmpreinteCarbone
     :dates-du-graph="suiviDuJourResultats.suivisPrecedent.datesDesSuivis"
     :valeurs-carbone-du-graph="suiviDuJourResultats.suivisPrecedent.valeursDesSuivis"
@@ -11,22 +10,13 @@
   />
 </template>
 
-<script lang="ts">
-import CarteEmpreinteDuJour from "@/components/CarteEmpreinteDuJour.vue";
-import EmpreinteDuJourDetails from "@/components/EmpreinteDuJourDetails.vue";
-import { SuiviDuJourResultatsViewModel } from "@/suivi/adapters/suiviDuJour.presenter.impl";
-import GraphSuiviEmpreinteCarbone from "@/components/GraphSuiviEmpreinteCarbone.vue";
+<script setup lang="ts">
+  import CarteEmpreinteDuJour from "@/components/CarteEmpreinteDuJour.vue";
+  import EmpreinteDuJourDetails from "@/components/EmpreinteDuJourDetails.vue";
+  import { SuiviDuJourResultatsViewModel } from "@/suivi/adapters/suiviDuJour.presenter.impl";
+  import GraphSuiviEmpreinteCarbone from "@/components/GraphSuiviEmpreinteCarbone.vue";
 
-export default {
-  name: "SuiviDuJourResultats",
-  components: { GraphSuiviEmpreinteCarbone, CarteEmpreinteDuJour, EmpreinteDuJourDetails },
-  props: {
-    suiviDuJourResultats: {
-      type: Object as () => SuiviDuJourResultatsViewModel,
-      required: true,
-    },
-  },
-};
+  defineProps<{
+    suiviDuJourResultats: SuiviDuJourResultatsViewModel
+  }>();
 </script>
-
-<style scoped></style>

--- a/src/suivi/adapters/suiviDuJour.repository.axios.ts
+++ b/src/suivi/adapters/suiviDuJour.repository.axios.ts
@@ -44,15 +44,18 @@ function getValeursDesSuivis(listeDesAdditionsCarbone: SuiviDuJourGraphDataApiMo
   return valeurDesSuivis;
 }
 
-function getValeursDesDates(listeDesAdditionsCarbone: SuiviDuJourGraphDataApiModel[]): string[] {
-  const valeurDesDates: string[] = [];
+function formateDate(date: string): string {
+  const inputDate = new Date(date);
 
-  for (let index = 0; index < listeDesAdditionsCarbone.length; index++) {
-    const additionCarbon = listeDesAdditionsCarbone[index];
-    const [dateDuSuivi, heureDuSuivi] = additionCarbon.date.split("T");
-    valeurDesDates.push(dateDuSuivi);
-  }
-  return valeurDesDates;
+  const day = String(inputDate.getUTCDate()).padStart(2, '0');
+  const month = String(inputDate.getUTCMonth() + 1).padStart(2, '0');
+  const year = String(inputDate.getUTCFullYear());
+
+  return `${day}/${month}/${year}`;
+}
+
+function getValeursDesDates(listeDesAdditionsCarbone: SuiviDuJourGraphDataApiModel[]): string[] {
+  return listeDesAdditionsCarbone.map(({ date }) => formateDate(date));
 }
 
 function calculerTempsEnMinute(temps: string): number {


### PR DESCRIPTION
Pour info je masque la légende par défaut de vue-chart-3 qui est difficile à custom car à l'intérieur d'un canvas.

:warning: warning a11y :warning: les lecteurs d'écran ne pourront pas lire le graphique. Il faudrait faire un point équipe (dev/ui) pour trouver une solution. (changeement de librairie, un tableau 'transcript', ...)