### PR TITLE
fix: catcher les erreurs chunk dans le router et forcer le reload

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -123,4 +123,12 @@ const router = createRouter({
   },
 });
 
+// Error handling to force refresh the page when a dynamic import fails
+router.onError((error) => {
+  if (error.message.includes('Failed to fetch dynamically imported module') || 
+      error.message.includes("Importing a module script failed")) {
+    window.location.reload();
+  }
+});
+
 export default router;


### PR DESCRIPTION
Catch errors in the router and force a reload. This avoids errors due to changes in chunk names.