### PR TITLE
Fix aides velo types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ package-lock.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.env

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 ## Introduction
+
 Accompagner les citoyens dans leur transition écologique, en leur proposant des informations, solutions adaptées à leur situation personnelle et leurs intérêts, et en rendant accessibles l’ensemble des aides à leur disposition
 
 ## Pile Technique
+
 - VueJS 3
 - Vitest
 - Playwright
 - [DSFR](https://www.systeme-de-design.gouv.fr/)
-
 
 ## Démarrage
 
@@ -20,11 +21,11 @@ $ yarn dev
 
 ## Commandes utiles
 
-- ```$ yarn test``` : lance les tests unitaires
-- ```$ yarn test:e2e``` : lance les tests end to end avec playwright
-
+- `$ yarn test` : lance les tests unitaires
+- `$ yarn test:e2e` : lance les tests end to end avec playwright
 
 ## Architecture
+
 L'architecture logicielle de ce projet repose sur une architecture Ports/Adapters.
 Le principe est d'isoler la valeur métier du front, et de pouvoir s'abstraire de tous frameworks et technologies.
 ![schéma d'architecture](./schema_archi.png)

--- a/src/domaines/aides/adapters/simulerAideVelo.repository.axios.ts
+++ b/src/domaines/aides/adapters/simulerAideVelo.repository.axios.ts
@@ -18,7 +18,14 @@ interface Collectivite {
   code?: string;
 }
 
-type TypeVelos = 'mécanique simple' | 'électrique' | 'cargo' | 'cargo électrique' | 'pliant' | 'motorisation';
+type TypeVelos =
+  | 'mécanique simple'
+  | 'électrique'
+  | 'cargo'
+  | 'cargo électrique'
+  | 'pliant'
+  | 'pliant électrique'
+  | 'motorisation';
 
 type AidesVeloParType = {
   [category in TypeVelos]: AidesVelo[];
@@ -31,6 +38,15 @@ export class SimulerAideVeloRepositoryAxios implements SimulerAideVeloRepository
     const response = await axiosInstance.post<AidesVeloParType>(`/utilisateurs/${utilisateurId}/simulerAideVelo`, {
       prix_du_velo: prixDuVelo,
     });
-    return response.data;
+
+    return {
+      'mécanique simple': response.data['mécanique simple'] ?? [],
+      électrique: response.data.électrique ?? [],
+      cargo: response.data.cargo ?? [],
+      'cargo électrique': response.data['cargo électrique'] ?? [],
+      pliant: response.data.pliant ?? [],
+      'pliant électrique': response.data['pliant électrique'] ?? [],
+      motorisation: response.data.motorisation ?? [],
+    };
   }
 }

--- a/src/domaines/aides/simulerAideVelo.usecase.ts
+++ b/src/domaines/aides/simulerAideVelo.usecase.ts
@@ -17,7 +17,14 @@ interface Collectivite {
   code?: string;
 }
 
-type TypeVelos = 'mécanique simple' | 'électrique' | 'cargo' | 'cargo électrique' | 'pliant' | 'motorisation';
+type TypeVelos =
+  | 'mécanique simple'
+  | 'électrique'
+  | 'cargo'
+  | 'cargo électrique'
+  | 'pliant'
+  | 'pliant électrique'
+  | 'motorisation';
 
 export type SimulationVelo = {
   [category in TypeVelos]: AidesVelo[];

--- a/tests/aides/simulerAideVelo.usecase.spec.ts
+++ b/tests/aides/simulerAideVelo.usecase.spec.ts
@@ -1,5 +1,5 @@
 import { SimulerAideVeloPresenterImpl } from '@/domaines/aides/adapters/simulerAideVelo.presenter.impl';
-import SimulerAideVeloUsecase, { SimulationVelo } from '@/domaines/aides/simulerAideVelo.usecase';
+import SimulerAideVeloUsecase from '@/domaines/aides/simulerAideVelo.usecase';
 import { SimulationAideResultatViewModel } from '@/domaines/aides/ports/simulationAideResultat';
 import { SimulerAideVeloRepositoryMock } from './adapters/simulerAideVelo.repository.mock';
 
@@ -207,6 +207,33 @@ describe('Fichier de tests pour simuler une aide velo', () => {
           logo: 'https://mesaidesvelo.fr/miniatures/logo_ile_de_france.webp',
         },
       ],
+      'pliant électrique': [
+        {
+          libelle: 'Bonus vélo',
+          description: 'Nouveau bonus vélo pliant applicable du 15 août 2022 au 31 décembre 2023.',
+          lien: 'https://www.service-public.fr/particuliers/vosdroits/F36828',
+          collectivite: {
+            kind: 'pays',
+            value: 'France',
+          },
+          montant: 2000,
+          plafond: 2000,
+          logo: 'https://mesaidesvelo.fr/miniatures/logo_etat_francais.webp',
+        },
+        {
+          libelle: 'Île-de-France Mobilités',
+          description:
+            'La région Île-de-France subventionne l’achat d’un vélo pliant à hauteur de 50% et jusqu’à un plafond de 500 €. Les éventuelles aides locales déjà perçues sont déduites de ce montant.',
+          lien: 'https://www.iledefrance-mobilites.fr/le-reseau/services-de-mobilite/velo/prime-achat-velo',
+          collectivite: {
+            kind: 'région',
+            value: '11',
+          },
+          montant: 550,
+          plafond: 550,
+          logo: 'https://mesaidesvelo.fr/miniatures/logo_ile_de_france.webp',
+        },
+      ],
       motorisation: [
         {
           libelle: 'Île-de-France Mobilités',
@@ -393,6 +420,27 @@ describe('Fichier de tests pour simuler une aide velo', () => {
           {
             aides: [
               {
+                libelle: 'Bonus vélo',
+                description: 'Nouveau bonus vélo pliant applicable du 15 août 2022 au 31 décembre 2023.',
+                lien: 'https://www.service-public.fr/particuliers/vosdroits/F36828',
+                montant: 2000,
+                logo: 'https://mesaidesvelo.fr/miniatures/logo_etat_francais.webp',
+              },
+              {
+                libelle: 'Île-de-France Mobilités',
+                description:
+                  'La région Île-de-France subventionne l’achat d’un vélo pliant à hauteur de 50% et jusqu’à un plafond de 500 €. Les éventuelles aides locales déjà perçues sont déduites de ce montant.',
+                lien: 'https://www.iledefrance-mobilites.fr/le-reseau/services-de-mobilite/velo/prime-achat-velo',
+                montant: 550,
+                logo: 'https://mesaidesvelo.fr/miniatures/logo_ile_de_france.webp',
+              },
+            ],
+            montantTotal: 2550,
+            titre: 'Acheter un vélo pliant électrique',
+          },
+          {
+            aides: [
+              {
                 description:
                   'La région Île-de-France subventionne l’achat d’un kit de motorisation à hauteur de 50% et jusqu’à un plafond de 200 €. Les éventuelles aides locales déjà perçues sont déduites de ce montant.',
                 libelle: 'Île-de-France Mobilités',
@@ -427,6 +475,7 @@ describe('Fichier de tests pour simuler une aide velo', () => {
         cargo: [],
         'cargo électrique': [],
         pliant: [],
+        'pliant électrique': [],
         motorisation: [],
       });
 
@@ -462,6 +511,11 @@ describe('Fichier de tests pour simuler une aide velo', () => {
               aides: [],
               montantTotal: 0,
               titre: 'Acheter un vélo pliant',
+            },
+            {
+              aides: [],
+              montantTotal: 0,
+              titre: 'Acheter un vélo pliant électrique',
             },
             {
               aides: [],


### PR DESCRIPTION
Cette PR ajoute le type `pliant électrique` et explicite le mapping de `AidesVeloParType` vers `SimulationVelo`.