### PR TITLE
feat: mise à jour du texte de feedback

### DIFF
--- a/src/components/custom/Coach/CoachContact.vue
+++ b/src/components/custom/Coach/CoachContact.vue
@@ -3,8 +3,8 @@
     <div class="fr-col-md-8">
       <h2 class="fr-h4 text--white">J'agis est un nouveau service qui continue de s’améliorer</h2>
       <p class="text--white fr-text--xl fr-mb-0">
-        N’hésitez pas à nous contacter par mail pour nous partager vos retours, poser vos questions et suggestions de
-        fonctionnalité que vous aimeriez voir sur <span class="text--italic">J'agis</span>.
+        Posez vos questions, partagez vos retours et suggérez de nouvelles fonctionnalités que vous aimeriez
+        voir sur <span class="text--italic">J'agis</span>.
       </p>
     </div>
     <div class="fr-col-md-4">


### PR DESCRIPTION
J'ai remarqué que le texte qui invite les utilisateurs à faire un retour parlait de "mail" alors qu'on a maintenant un formulaire.
Cette PR propose de changer le texte pour:

### J'agis est un nouveau service qui continue de s'améliorer

~~N’hésitez pas à nous contacter par mail pour nous partager vos retours, poser vos questions et suggestions de fonctionnalité que vous aimeriez voir sur J'agis.~~

`Posez vos questions, partagez vos retours et suggérez de nouvelles fonctionnalités que vous aimeriez voir sur J'agis`

